### PR TITLE
Switch from FixedThreadPool to VirtualThreadPerTaskExecutor

### DIFF
--- a/src/main/java/com/havanki/doppio/Server.java
+++ b/src/main/java/com/havanki/doppio/Server.java
@@ -61,8 +61,7 @@ public class Server {
    */
   public Server(ServerProperties serverProps) {
     this.serverProps = serverProps;
-    executorService =
-      Executors.newFixedThreadPool(serverProps.getNumThreads());
+    executorService = Executors.newVirtualThreadPerTaskExecutor();
   }
 
   private ServerSocket controlSocket;


### PR DESCRIPTION
Virtual threads are cheap and have next to no overhead, so they can be used on a per-connection basis. They are automatically mapped to (a limited and system-dependend number of) platform threads. 
So the number of concurrent connections it no longer limited by the number of fixed worker threads handling the connections. 